### PR TITLE
fix(timeout): add exception for timeout with exit status 256

### DIFF
--- a/src/pinger.cr
+++ b/src/pinger.cr
@@ -95,6 +95,9 @@ class Pinger
       @exception = err.chomp if err
 
       false # Transmission successful, no response.
+    when 256
+      @exception = "timed out"
+      false
     else
       if err
         @exception = err.chomp


### PR DESCRIPTION
Using `ping utility, iputils-s20161105` on Ubuntu 18.04 there is no message when ping times out. 
Pinger does however get exit status 256 from ping.
